### PR TITLE
Default field name as well as setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,16 @@ $ npm install --global @pauloportella/alfred-notion-quick-add
 
 ## Config
 
-Update the `.env` with your Notion token and the database you would like to connect to the workflow. You can also add the variables directly on Alfred.
+1. Create an integration at https://www.notion.so/my-integrations.  Note the "Internal Integration Token" this is your NOTION_TOKEN.
 
-```
-NOTION_TOKEN=
-DATABASE_ID=
-```
+2. Choose a Task database you want to add to. *IMPORTANT* ensure that the Title field is called "Name".  @TODO: Make this configurable
+
+3. Click Share, and share the database with your newly created integration.
+
+4. Click "copy link".  Take the long string of numbers and letters after http://notion.so/ and before the question mark.
+i.e. https://notion.so/abcdefg?whatever (abcdefg is your DATABASE_ID)
+
+5. Click on the configure button for this workflow (first one on the left in the top right of the screen.  Add in your NOTION_TOKEN and your DATABASE_ID.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -6,12 +6,10 @@
 
 ## Install
 
-Download from this [Release Page](https://github.com/pauloportella/alfred-notion-quick-add/releases)
-
-or via NPM
+via NPM
 
 ```
-$ npm install --global @pauloportella/alfred-notion-quick-add
+$ npm install --global @jacobsingh/alfred-notion-quick-add
 ```
 
 ## Config

--- a/README.md
+++ b/README.md
@@ -6,11 +6,7 @@
 
 ## Install
 
-via NPM
-
-```
-$ npm install --global @jacobsingh/alfred-notion-quick-add
-```
+Download from https://github.com/jacobSingh/alfred-notion-quick-add/releases
 
 ## Config
 

--- a/lib/notion.js
+++ b/lib/notion.js
@@ -24,7 +24,7 @@ export const addPageToDatabase = async (databaseId, text) => {
       body: {
         parent: { database_id: databaseId },
         properties: {
-          Task: {
+          Name: {
             title: [
               {
                 text: {


### PR DESCRIPTION
Updated the README for easier setup.  Also changed the name of the Ti…tle field to "Name" (which is the default Notion uses).

In the future, would be good to allow the user to select a database from the plugin config, but this is a start.